### PR TITLE
Fixes calling by reference

### DIFF
--- a/include/class.zipfile.php
+++ b/include/class.zipfile.php
@@ -180,7 +180,7 @@ class createZip  {
 	 * @param multi-d array $package
 	 * @param array $paths
 	 */
-	function addPOGPackage($package, $paths=array())
+	function addPOGPackage($package, &$paths=array())
 	{
 		
 		$i = 0;
@@ -195,7 +195,7 @@ class createZip  {
 			{
 				$paths[] = $key;
 				$this->addDirectory((($path == '') ? "$key/" : "$path/$key/"));
-				$this->addPOGPackage($package[$key], &$paths);
+				$this->addPOGPackage($package[$key], $paths);
 			}
 			else
 			{


### PR DESCRIPTION
Calling functions using reference sign on a function call  breaks the code on newer versions of PHP 5.

There is no reference sign on a function call - only on function definitions. Function definitions alone are enough to correctly pass the argument by reference.  See the [PHP docs](https://www.php.net/manual/en/language.references.pass.php)

